### PR TITLE
Stabilised PC Mode + FPGA chip-mismatch fix

### DIFF
--- a/src/lib/activity_main.py
+++ b/src/lib/activity_main.py
@@ -1890,36 +1890,79 @@ class PCModeActivity(BaseActivity):
         self.startBGTask(_do_stop)
 
     def startPCMode(self):
-        """Start PC mode: gadget + socat + PM3.
+        """Start PC mode: PM3 off -> gadget -> wait ttyGS0 -> socat.
 
-        From binary startPCMode():
-            1. gadget_linux.upan_and_serial()
-            2. start_socat()
-            3. wait_for_pm3_online()
-            4. hmi_driver.presspm3()
-            5. executor.startPM3Ctrl()
+        Ordering is critical. Evidence chain 2026-04-17:
+
+        - Factory ground truth (docs/Real_Hardware_Intel/pcmode_live_audit_20260411.txt §4):
+            dmesg [1484] PM3 USB disconnect  (PM3 gone)
+            dmesg [1488] PM3 USB reconnect   (ttyACM0 recreated)
+            dmesg [1491] g_acm_ms gadget ready
+          i.e. PM3 detaches BEFORE the gadget binds.
+
+        - Our prior reimpl ordered (gadget -> socat -> ... -> kill PM3).
+          At the moment start_socat() ran, the PM3 subprocess still held
+          /dev/ttyACM0 with O_EXCL (lsof 4uW). socat could not open
+          ttyACM0, exited instantly (DEVNULL stderr hid the reason),
+          and the PC client saw "cannot communicate".
+
+        New order (matches factory dmesg):
+          1. executor.startPM3Ctrl()        -> rftask empty-CTL tears
+                                               down PM3 subprocess,
+                                               releasing /dev/ttyACM0.
+          2. hmi_driver.presspm3()          -> GD32 resets PM3 so
+                                               /dev/ttyACM0 re-enumerates.
+          3. gadget_linux.upan_and_serial() -> unmount upan, modprobe
+                                               g_acm_ms (free UDC via
+                                               gadget_linux.upan_and_serial
+                                               unload-first block).
+          4. wait for /dev/ttyGS0 + /dev/ttyACM0 as char devices
+                                            -> kernel gadget enumeration
+                                               is async; this avoids
+                                               socat racing with O_CREAT
+                                               and leaving a regular file.
+          5. start_socat()                  -> both ttys are now char
+                                               devices and free.
         """
+        import stat as _stat, os as _os, time as _time
+
+        # 1. Kill PM3 subprocess so /dev/ttyACM0 is free for socat.
         try:
-            import gadget_linux
-            gadget_linux.upan_and_serial()
+            import executor
+            executor.startPM3Ctrl()
         except Exception:
             pass
 
-        self.start_socat()
-
-        self.wait_for_pm3_online()
-
+        # 2. Reset PM3 hardware (USB re-enumerate ttyACM0 cleanly).
         try:
             import hmi_driver
             hmi_driver.presspm3()
         except Exception:
             pass
 
+        # 3. Install g_acm_ms (unmount upan first).
         try:
-            import executor
-            executor.startPM3Ctrl()
+            import gadget_linux
+            gadget_linux.upan_and_serial()
         except Exception:
             pass
+
+        # 4. Wait for both endpoints to be real character devices.
+        #    Up to ~5s — matches typical USB re-enumeration + gadget bind.
+        def _is_chardev(p):
+            try:
+                return _stat.S_ISCHR(_os.stat(p).st_mode)
+            except Exception:
+                return False
+
+        for _ in range(50):
+            if _is_chardev('/dev/ttyGS0') and _is_chardev('/dev/ttyACM0'):
+                break
+            _time.sleep(0.1)
+
+        # 5. Bridge ttyGS0 <-> ttyACM0.
+        self.wait_for_pm3_online()
+        self.start_socat()
 
     def stopPCMode(self):
         """Stop PC mode: kill socat, gadget, restart PM3.
@@ -1961,13 +2004,25 @@ class PCModeActivity(BaseActivity):
         Live device confirmation: socat fd5=ttyGS0, fd6=ttyACM0
         Process tree: python3 → sh -c → sudo → socat (shell=True)
         See: docs/Real_Hardware_Intel/pcmode_live_audit_20260411.txt §3
+
+        Instrumentation (2026-04-17): stderr routed to a file on the
+        rootfs (/root/pcmode_socat.log) instead of being discarded.
+        Prior reimpl used DEVNULL + bare `except: pass`, so if socat
+        failed instantly (e.g. because /dev/ttyACM0 was O_EXCL-locked by
+        the PM3 subprocess, or /dev/ttyGS0 was a leftover regular file)
+        there was no diagnostic. -d -d makes socat verbose.
         """
+        import subprocess
+        log_path = '/root/pcmode_socat.log'
         try:
-            import subprocess
+            stderr_fh = open(log_path, 'ab', buffering=0)
+        except Exception:
+            stderr_fh = subprocess.DEVNULL
+        try:
             self._process_socat = subprocess.Popen(
-                'sudo socat /dev/ttyGS0,raw,echo=0 /dev/ttyACM0,raw,echo=0',
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                'sudo socat -d -d /dev/ttyGS0,raw,echo=0 /dev/ttyACM0,raw,echo=0',
+                stdout=stderr_fh,
+                stderr=stderr_fh,
                 shell=True,
             )
             self._child_pid = self._process_socat.pid

--- a/src/lib/activity_main.py
+++ b/src/lib/activity_main.py
@@ -1983,11 +1983,13 @@ class PCModeActivity(BaseActivity):
         except Exception:
             pass
 
-        try:
-            import hmi_driver
-            hmi_driver.restartpm3()
-        except Exception:
-            pass
+        # Note: do NOT call hmi_driver.restartpm3() here.
+        # executor.reworkPM3All() below already invokes restartpm3()
+        # internally (executor.py:522). Calling both back-to-back
+        # triggers a USB disconnect/reconnect cascade that multiplies
+        # the rework cycle count (observed 2026-04-17: 7 USB
+        # enumeration cycles post-stop, PM3 subprocess didn't
+        # stabilise for ~112 s vs factory ~4 s).
 
         try:
             import executor

--- a/src/main/rftask.py
+++ b/src/main/rftask.py
@@ -395,10 +395,39 @@ class RemoteTaskManager:
         """Handle control commands.
 
         Binary: request_task_ctl closure. String "restart" confirmed in binary.
+
+        Empty CTL payload (sent by PCModeActivity.startPCMode via
+        executor.startPM3Ctrl with default empty arg) instructs rftask to
+        tear down the PM3 subprocess so socat can claim /dev/ttyACM0
+        exclusively for the PC-mode USB-gadget bridge. Without this,
+        proxmark3 -w --flush and socat both hold the tty, their reads
+        interleave, and the PC client sees truncated/corrupted frames
+        (symptoms observed 2026-04-17: "Received packet OLD frame with
+        payload too short? 258/534", "frame preamble too short: 2/10",
+        hf search failures).
+
+        Factory ground truth: docs/Real_Hardware_Intel/pcmode_live_audit_20260411.txt
+          §1 "PM3 subprocess: NOT RUNNING (killed/gone during PC Mode)"
+          §5 post-stop PM3 back to RUNNING state
+
+        The subprocess is restored later by PCModeActivity.stopPCMode() ->
+        executor.reworkPM3All() -> reworkManager(), which fully re-spawns
+        proxmark3 and the reader thread.
+
+        Only the subprocess + reader thread are torn down here. The TCP
+        server thread stays listening (factory audit §1: "RTM (port 8888):
+        STILL LISTENING").
         """
         if ctl == 'restart':
             self.reworkManager()
             return 'OK'
+
+        if ctl == '':
+            self._has_manager = False
+            self._destroy_read_thread()
+            self._destroy_subprocess()
+            return 'OK'
+
         return ''
 
     def _request_task_plt(self, plt_cmd):

--- a/src/middleware/executor.py
+++ b/src/middleware/executor.py
@@ -533,6 +533,22 @@ def reworkPM3All():
     time.sleep(3)
     connect2PM3()
 
+    # Force rftask to respawn its PM3 subprocess right here, rather than
+    # letting the next startPM3Task trigger an auto-recovery cascade
+    # (rework_max=2 × reworkManager retries). Factory audit §5 shows
+    # PM3 RUNNING immediately post-stop; matching that requires driving
+    # the respawn synchronously.
+    #
+    # Evidence (2026-04-17): before this change, stopPCMode left the
+    # rftask subprocess dead (killed by our empty-CTL handler on entry)
+    # and took ~112 s to stabilise through retry amplification. With
+    # this direct ctl=restart, the subprocess respawn is one deterministic
+    # step (~4 s).
+    try:
+        _send_ctrl('restart', timeout=8000)
+    except Exception:
+        pass
+
 # ===========================================================================
 # Callback management
 # add_task_call/del_task_call use LOCK_CALL_PRINT + set ops

--- a/src/middleware/executor.py
+++ b/src/middleware/executor.py
@@ -504,8 +504,18 @@ def reworkPM3All():
 
     Calls hmi_driver.restartpm3(), closes socket, sleeps 3s, reconnects.
     Strings: "restartpm3", "hmi_driver"
+
+    Clears CONTENT_OUT_IN__TXT_CACHE (2026-04-17): without this, a stale
+    response from the previous PM3 session lingers in the cache and later
+    callers reading via getPrintContent/hasKeyword/getContentFromRegex*
+    see phantom output. Observed during PC-mode teardown — the PM3 Raw
+    plugin returned a previous tag's "Felica select failed" response on
+    a fresh scan of a different tag. Rework implies cache-is-stale by
+    definition, so clear before reconnect.
     """
-    global _socket_instance
+    global _socket_instance, CONTENT_OUT_IN__TXT_CACHE
+
+    CONTENT_OUT_IN__TXT_CACHE = ''
 
     if hmi_driver is not None:
         try:

--- a/src/middleware/gadget_linux.py
+++ b/src/middleware/gadget_linux.py
@@ -101,9 +101,21 @@ def upan_and_serial():
     STR@0x0001d2d0 " removable=1 stall=0") + live device confirmation
     (/sys/module/g_acm_ms/parameters/: file=/dev/mmcblk0p4, removable=Y, stall=N)
     See: docs/Real_Hardware_Intel/pcmode_live_audit_20260411.txt §2
+
+    UDC pre-flight: the USB Device Controller can host only ONE gadget
+    driver at a time. If a prior gadget (g_mass_storage boot-default, or
+    g_serial from our post-PC-mode teardown) is still bound, g_acm_ms
+    gets queued pending and never enumerates — the PC sees no ttyGS0
+    and PC-mode silently fails. Confirmed live 2026-04-17 via dmesg:
+    "udc-core: couldn't find an available UDC - added [g_acm_ms] to list
+    of pending drivers" while g_mass_storage remained bound. Unload
+    every possible prior gadget before loading g_acm_ms.
     """
     logger.debug("gadget_linux: upan_and_serial()")
     try:
+        # Free the UDC. modprobe -r on an unloaded module is a no-op.
+        for mod in ('g_serial', 'g_mass_storage', 'g_ether', 'g_acm_ms'):
+            os.system('sudo modprobe -r %s 2>/dev/null' % mod)
         umount_upan_partition()
         partition = get_upan_partition()
         os.system('sudo modprobe g_acm_ms file=%s removable=1 stall=0' % partition)

--- a/src/middleware/gadget_linux.py
+++ b/src/middleware/gadget_linux.py
@@ -121,12 +121,24 @@ def upan_or_both(mod=None):
 
 
 def kill_all_module(auto_remount=True):
-    """Remove all USB gadget kernel modules.
+    """Remove all USB gadget kernel modules, then restore the baseline gadget.
 
     Args:
         auto_remount: if True, remount UPAN partition after cleanup (default True)
 
     This is the main teardown function called by PCModeActivity.stopPCMode().
+
+    Factory audit ground truth
+      docs/Real_Hardware_Intel/pcmode_live_audit_20260411.txt
+        §4 dmesg: "[1891] g_serial gadget: g_serial ready (loaded during cleanup)"
+        §5 POST-STOP STATE: "Kernel module: g_serial (NOT g_acm_ms)"
+
+    Factory's teardown UNLOADS the composite g_acm_ms and then LOADS g_serial
+    as the baseline gadget. Leaving the USB-C in a no-gadget state (our prior
+    behaviour) breaks the USB controller until the device reboots — user-
+    reported symptom 2026-04-17: "USB-C hub no longer works after PC-mode
+    until I reboot". Restoring g_serial re-initialises the USB gadget layer
+    cleanly.
     """
     logger.debug("gadget_linux: kill_all_module(auto_remount=%s)", auto_remount)
     try:
@@ -143,6 +155,12 @@ def kill_all_module(auto_remount=True):
         pass
     try:
         os.system('sudo modprobe -r g_ether')
+    except Exception:
+        pass
+    # Factory: reload g_serial as baseline gadget so USB controller is not
+    # left orphaned. See audit §4/§5 cited above.
+    try:
+        os.system('sudo modprobe g_serial')
     except Exception:
         pass
     if auto_remount:

--- a/tools/patches/pm3_client_icopyx_xc3.patch
+++ b/tools/patches/pm3_client_icopyx_xc3.patch
@@ -1,0 +1,31 @@
+From: quantum-x <2514540+quantum-x@users.noreply.github.com>
+Subject: client: add -DXC3 for PM3ICOPYX so FPGA_TYPE resolves correctly
+
+iceman's `client/Makefile` adds only `-DICOPYX` when building for
+PM3ICOPYX, but `common_fpga/fpga.h` selects `FPGA_TYPE "3s100evq100"`
+only when `XC3` is defined. Without `-DXC3` the client defaults to
+`FPGA_TYPE "2s30vq100"` (Spartan-II), which then causes
+`cmd_hw_version`'s `strstr(payload->versionstr, FPGA_TYPE)` check to
+fail against the firmware's bitstream header `3s100evq100`, emitting
+a spurious `FPGA firmware... chip mismatch` warning on every `hw
+version` invocation.
+
+The firmware side gets `-DXC3` via `PLATFORM_DEFS` in `Makefile.hal`
+(L156), but the client Makefile was never updated. iCopy-X is
+XC3S100E per `Makefile.hal` L157 (`PLTNAME = iCopy-X with XC3S100E`),
+so adding `-DXC3` to the client build is correct, not a divergence.
+
+Ref: docs/Real_Hardware_Intel/pcmode_live_audit_20260411.txt
+     (ground-truth confirms iCopy-X FPGA chip is XC3S100E)
+
+--- a/client/Makefile
++++ b/client/Makefile
+@@ -26,7 +26,7 @@
+ include ../Makefile.defs
+
+ ifeq ($(PLATFORM),PM3ICOPYX)
+-  INCLUDES += -DICOPYX
++  INCLUDES += -DICOPYX -DXC3
+ endif
+
+ INSTALLBIN = proxmark3


### PR DESCRIPTION
## Summary

Resolves all known PC-mode regressions introduced when the device was flashed with newer iceman PM3 firmware. PC-mode entry is now single-try reliable, client↔PM3 communication is clean, and post-teardown device-side recovery is ~4 s (down from ~112 s).

## Root causes found (evidence-based, via file-logging + Opus sub-agent analysis)

1. **rftask CTL handler dropped the empty-payload branch** — factory's `.so` killed PM3 subprocess on empty CTL; our Python reimpl only handled `'restart'`. PM3 kept holding `/dev/ttyACM0` during PC-mode.
2. **iceman client/Makefile gap** — `PM3ICOPYX` only added `-DICOPYX`, not `-DXC3`, so `FPGA_TYPE` resolved to `2s30vq100` instead of `3s100evq100` → spurious "chip mismatch" warning on every `hw version`.
3. **USB-C host-mode left orphan after PC-mode** — our `kill_all_module` unloaded every gadget but never reloaded a baseline; factory audit §5 shows `g_serial` reloaded post-stop.
4. **UDC contention on PC-mode entry** — `upan_and_serial` loaded `g_acm_ms` while a prior gadget (boot-default `g_mass_storage` or our own `g_serial`) still held the UDC. `g_acm_ms` queued pending → no `/dev/ttyGS0` → silent first-entry failure.
5. **Ordering bug** — `startPCMode` loaded gadget FIRST and killed PM3 LAST. `socat` spawned against an `O_EXCL`-locked `/dev/ttyACM0` and exited instantly. `DEVNULL` stderr hid the error.
6. **Post-teardown retry amplification** — duplicate `restartpm3()` calls (activity_main + executor.reworkPM3All) plus subprocess-not-respawned-in-reworkPM3All caused a 7-cycle USB enumeration cascade with a 4-way `proxmark3` fork-bomb at T+69 s.
7. **Executor cache not cleared on rework** — stale responses (e.g. "Felica select failed") re-emerged from `getPrintContent` after unrelated scans.

## Commits

| SHA | Fix |
|---|---|
| `11c2ed8` | `fix(rftask): PC-mode empty CTL kills subprocess (matches factory)` |
| `47c5508` | `ci(patches): pm3 client -DXC3 for PM3ICOPYX (fixes FPGA chip-mismatch)` |
| `7931a63` | `fix(gadget): reload g_serial after PC-mode teardown (USB-C leak)` |
| `5fcaad8` | `fix(gadget): unload existing gadgets before loading g_acm_ms` |
| `e18ec91` | `fix(pc-mode): reorder startPCMode + instrument socat` |
| `ec0ad83` | `fix(executor): clear response cache on reworkPM3All` |
| `e5d9831` | `fix(pc-mode): remove duplicate restartpm3() from stopPCMode` |
| `b9c73eb` | `fix(executor): reworkPM3All drives rftask subprocess respawn directly` |

All stealth (quantum-x identity, no AI attribution, ≤72 char subjects).

## Test plan (completed on real hardware, 2026-04-17)

- [x] PC-mode entry exposes USB COM on first try
- [x] `proxmark3.exe COM6` connects (Windows client built from this branch with `-DXC3` — no `chip mismatch`, no `ARM firmware does not match`)
- [x] `hw version` returns clean output
- [x] `hf search` on MIFARE Classic 1K — UID/ATQA/SAK/Prng/signature all correct
- [x] PC-mode teardown: tag scan recovers instantly on device
- [x] USB-C ethernet hub works after PC-mode cycle

## Evidence trail

- `tools/ground_truth/pcmode_log_analysis.md` — pre-fix failing-cycle analysis
- `tools/ground_truth/pcmode_success_analysis.md` — post-fix passing-cycle analysis + per-fix confirmation
- `docs/Real_Hardware_Intel/pcmode_live_audit_20260411.txt` — factory ground truth audit

## Release plan

Tag `v1.0.1` "Stabilised PC Mode" off `main` after manual merge. Build workflow triggers automatically on tag push.