### PR TITLE
Changed Paxton Filename scheme

### DIFF
--- a/.github/workflows/build-ipk.yml
+++ b/.github/workflows/build-ipk.yml
@@ -179,6 +179,59 @@ jobs:
           print('Flash IPK verification PASSED')
           "
 
+      - name: Build and verify no-flash IPK
+        env:
+          ICOPYX_VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || (startsWith(github.ref, 'refs/tags/v') && github.ref_name || '') }}
+        run: |
+          python tools/build_ipk.py --sn UNIVERSAL --no-flash --output noflash.ipk
+
+          python3 -c "
+          import zipfile, sys
+          errors = []
+          with zipfile.ZipFile('noflash.ipk') as z:
+              names = set(z.namelist())
+
+              # Core structure
+              for req in ['app.py', 'data/conf.ini']:
+                  if req not in names:
+                      errors.append(f'MISSING: {req}')
+
+              # Python modules
+              py_libs = [n for n in names if n.startswith('lib/') and n.endswith('.py')]
+              if len(py_libs) < 50:
+                  errors.append(f'Too few lib/*.py: {len(py_libs)} (expected 50+)')
+
+              # PM3 binary + lua (factory versions from build/)
+              if 'pm3/proxmark3' not in names:
+                  errors.append('MISSING: pm3/proxmark3')
+              if 'pm3/lua.zip' not in names:
+                  errors.append('MISSING: pm3/lua.zip')
+
+              # PM3 binary should be factory (smaller than iceman)
+              if 'pm3/proxmark3' in names:
+                  pm3_size = z.getinfo('pm3/proxmark3').file_size
+                  if pm3_size > 3000000:
+                      errors.append(f'pm3/proxmark3 too large ({pm3_size}b) — expected factory client (<3MB)')
+
+              # Firmware (MUST NOT be present in no-flash IPK)
+              fw = [n for n in names if 'firmware' in n and n.endswith('.elf')]
+              if len(fw) > 0:
+                  errors.append(f'UNEXPECTED: firmware .elf in no-flash IPK: {fw}')
+
+              # Plugins
+              plugins = [n for n in names if n.startswith('plugins/')]
+              if len(plugins) < 5:
+                  errors.append(f'Too few plugin files: {len(plugins)}')
+
+              print(f'No-flash IPK: {len(names)} files, {len(py_libs)} py, {len(fw)} firmware (should be 0)')
+
+          if errors:
+              for e in errors:
+                  print(f'::error::{e}')
+              sys.exit(1)
+          print('No-flash IPK verification PASSED')
+          "
+
   cross-compile-pm3:
     name: Cross-compile Proxmark3 Client
     needs: [resolve-pm3-tag, ensure-tag]
@@ -510,11 +563,22 @@ jobs:
           ICOPYX_VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || (startsWith(github.ref, 'refs/tags/v') && github.ref_name || '') }}
         run: python tools/build_ipk.py --sn UNIVERSAL --output icopy-x-flash.ipk
 
+      - name: Build no-flash IPK
+        env:
+          ICOPYX_VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || (startsWith(github.ref, 'refs/tags/v') && github.ref_name || '') }}
+        run: python tools/build_ipk.py --sn UNIVERSAL --no-flash --output icopy-x-noflash.ipk
+
       - name: Upload flash IPK
         uses: actions/upload-artifact@v4
         with:
           name: icopy-x-flash-ipk
           path: icopy-x-flash.ipk
+
+      - name: Upload no-flash IPK
+        uses: actions/upload-artifact@v4
+        with:
+          name: icopy-x-noflash-ipk
+          path: icopy-x-noflash.ipk
 
   release:
     name: Create Release
@@ -535,6 +599,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: icopy-x-flash-ipk
+
+      - name: Download no-flash IPK
+        uses: actions/download-artifact@v4
+        with:
+          name: icopy-x-noflash-ipk
 
       - name: Download iceman clients
         uses: actions/download-artifact@v4
@@ -565,32 +634,50 @@ jobs:
           cd /tmp/clients-flash && zip -r ${{ github.workspace }}/clients-flash.zip .
           echo "=== clients-flash.zip ===" && find . -type d | sort
 
+      - name: Package clients-noflash.zip
+        run: |
+          mkdir -p /tmp/clients-noflash/linux /tmp/clients-noflash/windows /tmp/clients-noflash/macos
+          # Binaries per platform
+          cp build/clients/factory/linux/proxmark3 /tmp/clients-noflash/linux/
+          cp build/clients/factory/macos/proxmark3 /tmp/clients-noflash/macos/
+          cp -r build/clients/factory/windows/* /tmp/clients-noflash/windows/
+          # Shared data (factory lualibs/luascripts/hardnested/json)
+          cp -r build/clients/factory/share/* /tmp/clients-noflash/
+          cd /tmp/clients-noflash && zip -r ${{ github.workspace }}/clients-noflash.zip .
+          echo "=== clients-noflash.zip ===" && find . -type d | sort
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           files: |
             icopy-x-flash.ipk
+            icopy-x-noflash.ipk
             clients-flash.zip
+            clients-noflash.zip
           body: |
             ## iCopy-X Open Source Firmware ${{ env.RELEASE_TAG }}
 
-            ### IPK
+            ### Two IPK variants
 
-            | File | PM3 firmware | LUA scripts |
-            |------|-------------|-------------|
-            | `icopy-x-flash.ipk` | RRG/Iceman (included) | Lua 5.4 (iceman) |
+            | File | PM3 firmware | LUA scripts | Use when |
+            |------|-------------|-------------|----------|
+            | `icopy-x-flash.ipk` | RRG/Iceman (included) | Lua 5.4 (iceman) | You want the latest PM3 client + firmware |
+            | `icopy-x-noflash.ipk` | Unchanged (factory) | Lua 5.1 (factory) | You want to keep your current PM3 version |
 
             ### Installation
 
             1. Ensure that your device is up to date (1.0.90 - get it from here: https://icopyx.com/pages/update-your-icopy-x)
-            2. Download the IPK
+            2. Download the IPK of your choice
             3. Put your iCopy-X into PC-Mode
             4. Delete ALL OTHER IPK files from the device
             5. Transfer the IPK onto your device and close PC-Mode
             6. Navigate to About > Update, and press [OK]
             7. Device will restart
             8. While restarting, the screen will flash and stay blank for up to 10 seconds. Don't panic!
+
+            If you're using the "flash" version, there will be some extra steps:
+
             9. Device will restart and detect that you need to flash your device. Click OK.
             10. Read the instructions: Make sure your device has charge, make sure it's plugged in, and then Start
             11. After flashing, your device will restart.
@@ -603,10 +690,11 @@ jobs:
             | File | PM3 version | Contents |
             |------|------------|----------|
             | `clients-flash.zip` | RRG/Iceman ${{ env.PM3_TAG }} | Linux x86_64 + macOS + Windows CLI clients |
+            | `clients-noflash.zip` | Factory (iCopy-X original) | Windows client (pre-built) |
 
             ### Using the companion client
 
-            1. Download `clients-flash.zip`
+            1. Download the matching `clients-[flash|noflash].zip` for your IPK variant
             2. Extract to a folder on your computer
             3. Put your iCopy-X into PC-Mode
             4. Connect via USB

--- a/.github/workflows/build-ipk.yml
+++ b/.github/workflows/build-ipk.yml
@@ -179,59 +179,6 @@ jobs:
           print('Flash IPK verification PASSED')
           "
 
-      - name: Build and verify no-flash IPK
-        env:
-          ICOPYX_VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || (startsWith(github.ref, 'refs/tags/v') && github.ref_name || '') }}
-        run: |
-          python tools/build_ipk.py --sn UNIVERSAL --no-flash --output noflash.ipk
-
-          python3 -c "
-          import zipfile, sys
-          errors = []
-          with zipfile.ZipFile('noflash.ipk') as z:
-              names = set(z.namelist())
-
-              # Core structure
-              for req in ['app.py', 'data/conf.ini']:
-                  if req not in names:
-                      errors.append(f'MISSING: {req}')
-
-              # Python modules
-              py_libs = [n for n in names if n.startswith('lib/') and n.endswith('.py')]
-              if len(py_libs) < 50:
-                  errors.append(f'Too few lib/*.py: {len(py_libs)} (expected 50+)')
-
-              # PM3 binary + lua (factory versions from build/)
-              if 'pm3/proxmark3' not in names:
-                  errors.append('MISSING: pm3/proxmark3')
-              if 'pm3/lua.zip' not in names:
-                  errors.append('MISSING: pm3/lua.zip')
-
-              # PM3 binary should be factory (smaller than iceman)
-              if 'pm3/proxmark3' in names:
-                  pm3_size = z.getinfo('pm3/proxmark3').file_size
-                  if pm3_size > 3000000:
-                      errors.append(f'pm3/proxmark3 too large ({pm3_size}b) — expected factory client (<3MB)')
-
-              # Firmware (MUST NOT be present in no-flash IPK)
-              fw = [n for n in names if 'firmware' in n and n.endswith('.elf')]
-              if len(fw) > 0:
-                  errors.append(f'UNEXPECTED: firmware .elf in no-flash IPK: {fw}')
-
-              # Plugins
-              plugins = [n for n in names if n.startswith('plugins/')]
-              if len(plugins) < 5:
-                  errors.append(f'Too few plugin files: {len(plugins)}')
-
-              print(f'No-flash IPK: {len(names)} files, {len(py_libs)} py, {len(fw)} firmware (should be 0)')
-
-          if errors:
-              for e in errors:
-                  print(f'::error::{e}')
-              sys.exit(1)
-          print('No-flash IPK verification PASSED')
-          "
-
   cross-compile-pm3:
     name: Cross-compile Proxmark3 Client
     needs: [resolve-pm3-tag, ensure-tag]
@@ -563,22 +510,11 @@ jobs:
           ICOPYX_VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || (startsWith(github.ref, 'refs/tags/v') && github.ref_name || '') }}
         run: python tools/build_ipk.py --sn UNIVERSAL --output icopy-x-flash.ipk
 
-      - name: Build no-flash IPK
-        env:
-          ICOPYX_VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || (startsWith(github.ref, 'refs/tags/v') && github.ref_name || '') }}
-        run: python tools/build_ipk.py --sn UNIVERSAL --no-flash --output icopy-x-noflash.ipk
-
       - name: Upload flash IPK
         uses: actions/upload-artifact@v4
         with:
           name: icopy-x-flash-ipk
           path: icopy-x-flash.ipk
-
-      - name: Upload no-flash IPK
-        uses: actions/upload-artifact@v4
-        with:
-          name: icopy-x-noflash-ipk
-          path: icopy-x-noflash.ipk
 
   release:
     name: Create Release
@@ -599,11 +535,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: icopy-x-flash-ipk
-
-      - name: Download no-flash IPK
-        uses: actions/download-artifact@v4
-        with:
-          name: icopy-x-noflash-ipk
 
       - name: Download iceman clients
         uses: actions/download-artifact@v4
@@ -634,50 +565,32 @@ jobs:
           cd /tmp/clients-flash && zip -r ${{ github.workspace }}/clients-flash.zip .
           echo "=== clients-flash.zip ===" && find . -type d | sort
 
-      - name: Package clients-noflash.zip
-        run: |
-          mkdir -p /tmp/clients-noflash/linux /tmp/clients-noflash/windows /tmp/clients-noflash/macos
-          # Binaries per platform
-          cp build/clients/factory/linux/proxmark3 /tmp/clients-noflash/linux/
-          cp build/clients/factory/macos/proxmark3 /tmp/clients-noflash/macos/
-          cp -r build/clients/factory/windows/* /tmp/clients-noflash/windows/
-          # Shared data (factory lualibs/luascripts/hardnested/json)
-          cp -r build/clients/factory/share/* /tmp/clients-noflash/
-          cd /tmp/clients-noflash && zip -r ${{ github.workspace }}/clients-noflash.zip .
-          echo "=== clients-noflash.zip ===" && find . -type d | sort
-
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           files: |
             icopy-x-flash.ipk
-            icopy-x-noflash.ipk
             clients-flash.zip
-            clients-noflash.zip
           body: |
             ## iCopy-X Open Source Firmware ${{ env.RELEASE_TAG }}
 
-            ### Two IPK variants
+            ### IPK
 
-            | File | PM3 firmware | LUA scripts | Use when |
-            |------|-------------|-------------|----------|
-            | `icopy-x-flash.ipk` | RRG/Iceman (included) | Lua 5.4 (iceman) | You want the latest PM3 client + firmware |
-            | `icopy-x-noflash.ipk` | Unchanged (factory) | Lua 5.1 (factory) | You want to keep your current PM3 version |
+            | File | PM3 firmware | LUA scripts |
+            |------|-------------|-------------|
+            | `icopy-x-flash.ipk` | RRG/Iceman (included) | Lua 5.4 (iceman) |
 
             ### Installation
 
             1. Ensure that your device is up to date (1.0.90 - get it from here: https://icopyx.com/pages/update-your-icopy-x)
-            2. Download the IPK of your choice
+            2. Download the IPK
             3. Put your iCopy-X into PC-Mode
             4. Delete ALL OTHER IPK files from the device
             5. Transfer the IPK onto your device and close PC-Mode
             6. Navigate to About > Update, and press [OK]
             7. Device will restart
             8. While restarting, the screen will flash and stay blank for up to 10 seconds. Don't panic!
-
-            If you're using the "flash" version, there will be some extra steps:
-
             9. Device will restart and detect that you need to flash your device. Click OK.
             10. Read the instructions: Make sure your device has charge, make sure it's plugged in, and then Start
             11. After flashing, your device will restart.
@@ -690,11 +603,10 @@ jobs:
             | File | PM3 version | Contents |
             |------|------------|----------|
             | `clients-flash.zip` | RRG/Iceman ${{ env.PM3_TAG }} | Linux x86_64 + macOS + Windows CLI clients |
-            | `clients-noflash.zip` | Factory (iCopy-X original) | Windows client (pre-built) |
 
             ### Using the companion client
 
-            1. Download the matching `clients-[flash|noflash].zip` for your IPK variant
+            1. Download `clients-flash.zip`
             2. Extract to a folder on your computer
             3. Put your iCopy-X into PC-Mode
             4. Connect via USB

--- a/src/lib/activity_main.py
+++ b/src/lib/activity_main.py
@@ -7102,6 +7102,13 @@ class CardWalletActivity(BaseActivity):
         if m:
             return '%s(%s)' % (m.group(1), m.group(2))
 
+        # Paxton: {Paxton}-ID_{UID}_{Block5}_{index} — two identity fields.
+        # Matched before the UID-based regex so an all-decimal Block5 isn't
+        # mistaken for the file index.
+        m = re.match(r'^Paxton-ID_(.+)_(\d+)$', base)
+        if m:
+            return '%s(%s)' % (m.group(1), m.group(2))
+
         # UID-based (MFU, Felica, ICODE, HF14A): {Prefix}_{UID}_{index}
         m = re.match(r'[A-Za-z0-9]+-?[A-Za-z0-9]*_([A-Fa-f\d]+)_(\d+)', base)
         if m:

--- a/src/middleware/lfread.py
+++ b/src/middleware/lfread.py
@@ -167,7 +167,7 @@ def _stem_from_identity(ident):
     return ident.replace(' ', '').replace(':', '_').replace(',', '-')
 
 
-def _save_txt(typ, uid, raw, display=None, extras=None):
+def _save_txt(typ, uid, raw, display=None, extras=None, fname_ident=None):
     """Save an LF read result as a multi-line .txt dump (format v2).
 
         line 1  : raw hex  — WRITE payload (the only line the write path reads).
@@ -199,6 +199,8 @@ def _save_txt(typ, uid, raw, display=None, extras=None):
         display: display string for line 2 (defaults to uid, then raw); also
                  the sim source for single-field tags.
         extras:  optional dict of per-field sim values for line 3+.
+        fname_ident: optional filename identity, decoupling the filename from
+                 line 2 (display); defaults to the line-2 identity when unset.
     """
     try:
         import appfiles
@@ -217,7 +219,7 @@ def _save_txt(typ, uid, raw, display=None, extras=None):
                 if v is not None and v != '':
                     lines.append('%s=%s' % (k, v))
 
-        ident = display or uid or raw or ''
+        ident = fname_ident if fname_ident else (display or uid or raw or '')
         safe = _stem_from_identity(ident)
         stem = '%s-ID_%s' % (prefix, safe)
 
@@ -836,7 +838,10 @@ def readPaxton(listener=None, infos=None, save=True):
         if save:
             hitag2_uid = executor.getContentFromRegexG(r'UID\.{3,}\s+([0-9A-Fa-f]+)', 1)
             hitag2_uid = hitag2_uid.strip() if hitag2_uid else ''
-            _save_txt(49, paxton_id, payload, extras={'uid': hitag2_uid, 'type': 'switch2'})
+            _pax_ident = ('%s_%s' % (hitag2_uid, payload[8:16])).upper() if hitag2_uid else payload[8:16].upper()
+            _save_txt(49, hitag2_uid, payload,
+                      extras={'uid': hitag2_uid, 'type': 'switch2'},
+                      fname_ident=_pax_ident)
         result = createRetObj(paxton_id, payload, 1)
         result['type'] = 49
         return result
@@ -845,7 +850,10 @@ def readPaxton(listener=None, infos=None, save=True):
     if save:
         hitag2_uid = executor.getContentFromRegexG(r'UID\.{3,}\s+([0-9A-Fa-f]+)', 1)
         hitag2_uid = hitag2_uid.strip() if hitag2_uid else ''
-        _save_txt(48, paxton_id, payload, extras={'uid': hitag2_uid, 'type': 'net2'})
+        _pax_ident = ('%s_%s' % (hitag2_uid, payload[8:16])).upper() if hitag2_uid else payload[8:16].upper()
+        _save_txt(48, hitag2_uid, payload,
+                  extras={'paxid': paxton_id, 'uid': hitag2_uid, 'type': 'net2'},
+                  fname_ident=_pax_ident)
         # Secondary EM410x dump — padded Paxton ID for direct EM clone
         _save_txt(8, paxton_id, paxton_id)
 

--- a/src/middleware/scan.py
+++ b/src/middleware/scan.py
@@ -421,15 +421,20 @@ def scan_hitag_paxton():
                         if nib5 == '1' and int(nib4, 16) % 2 == 0:
                             tag_type = tagtypes.PAXTON_SWITCH2_ID
 
+            _padded_pax = paxton_hex.strip().zfill(10) if paxton_hex else ''
             info = {
                 'found': True,
                 'type': tag_type,
-                'data': paxton_hex.strip().zfill(10) if paxton_hex else '',
+                'data': _padded_pax,
                 'raw': '',
                 'uid': uid_raw.strip() if uid_raw else '',
                 'progress': 1,
                 'return': tag_type,
             }
+            # PaxID is valid for Net2 only; dedicated field so the renderer
+            # never confuses it with UID or generic data.
+            if tag_type == tagtypes.PAXTON_NET2_ID:
+                info['paxid'] = _padded_pax
             return info
         return createTagNoFound(1)
     except Exception:

--- a/src/middleware/template.py
+++ b/src/middleware/template.py
@@ -847,8 +847,9 @@ def __drawPaxton(data, parent):
     Switch2 (type 49):
       line 1 (y=128): UID: <Hitag2 internal UID>         e.g. A4B90915
 
-    data['data'] holds the 5-byte padded hex Paxton ID.
-    data['uid']  holds the Hitag2 internal UID from lf search.
+    data['paxid'] holds the 5-byte padded hex Paxton ID (Net2 only; older
+                  dumps fall back to data['data']).
+    data['uid']   holds the Hitag2 internal UID from lf search.
     """
     __drawFinalByData(data, parent)
     if data is None:
@@ -859,7 +860,7 @@ def __drawPaxton(data, parent):
     is_switch2 = (typ == 49)
 
     if not is_switch2:
-        paxton_id = data.get('data', '')
+        paxton_id = data.get('paxid') or data.get('data', '')
         if paxton_id:
             parent.create_text(
                 _LEFT_X, _DATA_START_Y,


### PR DESCRIPTION
#### Change Paxton Filename scheme

This update changes the way Paxton dumps are saved, they are currently saved as `Paxton-ID_<PaddedPaxID>_N.txt` the new naming scheme changes this to `Paxton-ID_<UID>_<Block5>_N.txt` with added fallback support for older dumps.

The new dump contents are as follows

**Net2 Dump File:**
```
B4-7
UID
paxid=<paddedpaxID>
uid=<UID>
type=net2
```
and for **Switch2 Dump File:**

```
B4-7
UID
uid=<UID>
type=switch2
```

This keeps switch2 with 4 lines and removes the paxID which needed to be done also. I have tested the changes and it is working just fine with the older dumps and the new. I had meant to fit this in with the previous PR but I had not been around today much so I did not make it in time.

I changed the workflow momentarily and reverted it back for the PR so its safe for merge and does not affect your current workflow :)