### PR TITLE
Ignore macOS AppleDouble (._*) files in firmware update search (fixes #10)

### DIFF
--- a/src/middleware/update.py
+++ b/src/middleware/update.py
@@ -62,6 +62,21 @@ _REQUIRED_EITHER = [
 _found_ipk = None
 
 
+def _is_hidden(name):
+    """Return True for hidden/metadata filesystem entries, not real artifacts.
+
+    macOS writes an AppleDouble sidecar (``._<name>``) next to every file it
+    copies onto a non-native filesystem such as the iCopy-X USB volume, and
+    adds directories like ``.Spotlight-V100``, ``.Trashes`` and ``.fseventsd``.
+    None of these are valid firmware artifacts.  A ``._<name>.ipk`` sidecar in
+    particular sorts ahead of the real ``<name>.ipk`` and would otherwise be
+    selected first, causing the flash to fail with error 0x05.  A legitimate
+    IPK or firmware file never begins with a dot, so skipping dot-prefixed
+    entries is safe.
+    """
+    return name.startswith('.')
+
+
 def search(path):
     """Search for .ipk firmware files in the given directory.
 
@@ -82,6 +97,10 @@ def search(path):
 
     try:
         for entry in sorted(os.listdir(path)):
+            if _is_hidden(entry):
+                # Skip macOS AppleDouble sidecars (._foo.ipk) and other
+                # hidden/metadata files that Finder writes onto the USB.
+                continue
             if entry.lower().endswith(_IPK_EXTENSION):
                 full_path = os.path.join(path, entry)
                 if os.path.isfile(full_path):
@@ -293,6 +312,10 @@ def _scan_fw_dir(keyword, extension):
     try:
         if os.path.exists(_FW_PATH):
             for f in os.listdir(_FW_PATH):
+                if _is_hidden(f):
+                    # Ignore macOS AppleDouble sidecars (._foo.pm3) and other
+                    # hidden files copied alongside real firmware.
+                    continue
                 if f.endswith(extension):
                     if keyword is None or keyword in f.lower():
                         results.append(os.path.join(_FW_PATH, f))

--- a/tests/ui/test_update_search.py
+++ b/tests/ui/test_update_search.py
@@ -1,0 +1,60 @@
+"""Regression tests for update.search() / _scan_fw_dir() macOS handling.
+
+macOS writes an AppleDouble sidecar (``._<name>``) next to every file copied
+onto the iCopy-X USB volume.  Because ``._icopy-x-flash.ipk`` sorts ahead of
+``icopy-x-flash.ipk``, the updater used to select the sidecar and fail the
+flash with error 0x05 (issue #10).  These tests pin the fix so it cannot
+silently regress.
+"""
+
+import os
+
+import update
+
+
+def _touch(path, data=b"stub"):
+    with open(path, "wb") as f:
+        f.write(data)
+
+
+def test_search_ignores_appledouble_sidecar(tmp_path):
+    real = os.path.join(str(tmp_path), "icopy-x-flash.ipk")
+    sidecar = os.path.join(str(tmp_path), "._icopy-x-flash.ipk")
+    _touch(real)
+    _touch(sidecar)
+
+    # Sanity check: the sidecar sorts first — the exact condition that used
+    # to make search() pick the wrong file.
+    assert sorted(os.listdir(str(tmp_path)))[0] == "._icopy-x-flash.ipk"
+
+    assert update.search(str(tmp_path)) == real
+
+
+def test_search_returns_none_when_only_sidecar(tmp_path):
+    _touch(os.path.join(str(tmp_path), "._icopy-x-flash.ipk"))
+    assert update.search(str(tmp_path)) is None
+
+
+def test_search_finds_real_ipk_without_sidecar(tmp_path):
+    real = os.path.join(str(tmp_path), "update.ipk")
+    _touch(real)
+    assert update.search(str(tmp_path)) == real
+
+
+def test_is_hidden():
+    assert update._is_hidden("._icopy-x-flash.ipk")
+    assert update._is_hidden(".DS_Store")
+    assert not update._is_hidden("icopy-x-flash.ipk")
+    assert not update._is_hidden("update.ipk")
+
+
+def test_scan_fw_dir_ignores_appledouble(tmp_path, monkeypatch):
+    fw = os.path.join(str(tmp_path), "fw")
+    os.mkdir(fw)
+    _touch(os.path.join(fw, "fullimage.pm3"))
+    _touch(os.path.join(fw, "._fullimage.pm3"))
+    monkeypatch.setattr(update, "_FW_PATH", fw + os.sep)
+
+    results = update._scan_fw_dir(None, ".pm3")
+    names = sorted(os.path.basename(r) for r in results)
+    assert names == ["fullimage.pm3"]


### PR DESCRIPTION
## Problem

When a Mac copies an `.ipk` onto the iCopy-X USB volume, Finder writes an AppleDouble sidecar named `._<name>.ipk` alongside it. `update.search()` walked the directory in sorted order and returned the first `.ipk` it found. Because `._…` sorts ahead of the real package, the sidecar was selected, `checkPkg()` rejected it, and the flash aborted with error `0x05`.

Reported in #10.

## Fix

Skip dot-prefixed entries in both `search()` and `_scan_fw_dir()`, via a small `_is_hidden()` helper. This covers AppleDouble sidecars as well as `.DS_Store`, `.Spotlight-V100`, `.Trashes` and similar Finder metadata. A valid IPK or firmware file never begins with a dot, so the guard is safe.

## Tests

Adds `tests/ui/test_update_search.py` (5 cases): sidecar ignored when the real IPK is present, sidecar-only returns `None`, clean lookup still works, `_is_hidden()` behaviour, and AppleDouble filtering in the firmware scan. All pass locally.

No behaviour change on Linux or Windows, where these sidecars do not exist.

Fixes #10