### PR TITLE
Ship PM3 client data inside each platform folder (fixes #13)

### DIFF
--- a/.github/workflows/build-ipk.yml
+++ b/.github/workflows/build-ipk.yml
@@ -626,13 +626,24 @@ jobs:
           cp /tmp/iceman-linux/linux/* /tmp/clients-flash/linux/
           cp /tmp/iceman-windows/* /tmp/clients-flash/windows/
           cp /tmp/iceman-macos/* /tmp/clients-flash/macos/
-          # Shared data from Linux build (iceman lualibs/luascripts/resources)
-          for d in lualibs luascripts resources; do
-            [ -d /tmp/iceman-linux/$d ] && cp -r /tmp/iceman-linux/$d /tmp/clients-flash/
+          # Ship the client's data (resources/, dictionaries/, lualibs/,
+          # luascripts/) INSIDE each platform folder, next to the binary.
+          # The PM3 client resolves these relative to its own executable, so a
+          # single shared copy at the zip root was never found once the binary
+          # lived in a subfolder. On macOS this silently disabled the
+          # hardnested bitflip tables and benchmark data (issue #13).
+          for p in linux windows macos; do
+            for d in lualibs luascripts resources; do
+              [ -d /tmp/iceman-linux/$d ] && cp -r /tmp/iceman-linux/$d /tmp/clients-flash/$p/
+            done
+            if ls /tmp/iceman-linux/*.dic >/dev/null 2>&1; then
+              mkdir -p /tmp/clients-flash/$p/dictionaries
+              cp /tmp/iceman-linux/*.dic /tmp/clients-flash/$p/dictionaries/
+            fi
           done
-          cp /tmp/iceman-linux/*.dic /tmp/clients-flash/ 2>/dev/null || true
           cd /tmp/clients-flash && zip -r ${{ github.workspace }}/clients-flash.zip .
-          echo "=== clients-flash.zip ===" && find . -type d | sort
+          echo "=== clients-flash.zip layout ===" && find . -maxdepth 2 -type d | sort
+          echo "=== per-platform sizes ===" && du -sh /tmp/clients-flash/*/ | sort
 
       - name: Package clients-noflash.zip
         run: |
@@ -641,10 +652,15 @@ jobs:
           cp build/clients/factory/linux/proxmark3 /tmp/clients-noflash/linux/
           cp build/clients/factory/macos/proxmark3 /tmp/clients-noflash/macos/
           cp -r build/clients/factory/windows/* /tmp/clients-noflash/windows/
-          # Shared data (factory lualibs/luascripts/hardnested/json)
-          cp -r build/clients/factory/share/* /tmp/clients-noflash/
+          # Ship the factory client's data next to each binary, not at the zip
+          # root, so it is found relative to the executable on every platform
+          # (same root cause as the flash client — issue #13).
+          for p in linux windows macos; do
+            cp -r build/clients/factory/share/* /tmp/clients-noflash/$p/
+          done
           cd /tmp/clients-noflash && zip -r ${{ github.workspace }}/clients-noflash.zip .
-          echo "=== clients-noflash.zip ===" && find . -type d | sort
+          echo "=== clients-noflash.zip layout ===" && find . -maxdepth 2 -type d | sort
+          echo "=== per-platform sizes ===" && du -sh /tmp/clients-noflash/*/ | sort
 
       - name: Create Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Problem

The client release zips (`clients-flash.zip`, `clients-noflash.zip`) put each binary in a per-OS subfolder (`linux/`, `macos/`, `windows/`) but kept the shared `resources/`, `dictionaries/`, `lualibs/` and `luascripts/` at the zip root:

```
clients-flash/
  macos/proxmark3        <- runs from here
  resources/  *.dic  lualibs/  luascripts/   <- one level up, never found
```

The PM3 client resolves `resources/` and `dictionaries/` relative to its own executable. Once the binary sits in a subfolder, the root copy is never located. On macOS this silently fell back to zero bitflip state tables and no benchmark data, so `hardnested`/`autopwn` crawled — the reporter measured ~94 minutes for a sector that takes ~1 minute once the data is found.

Reported in #13.

## Fix

Copy the client data into each platform folder, next to the binary, in both the flash and no-flash packaging steps. The loose `.dic` files now go under a `dictionaries/` subfolder, where the client actually looks. Each platform folder is self-contained and works out of the box on Linux, macOS and Windows.

```
clients-flash/
  macos/{proxmark3, resources/, dictionaries/, lualibs/, luascripts/}
  linux/{proxmark3, resources/, dictionaries/, lualibs/, luascripts/}
  windows/{proxmark3.exe + dlls, resources/, dictionaries/, lualibs/, luascripts/}
```

The one trade-off is that the shared data (~6 MB) is duplicated across the three platform folders inside each zip.

## Validation

This lives in the `release` job, which only runs on a tag push, so it is **not exercised by PR CI**. I validated the packaging logic locally against the real factory client tree and a faked iceman artifact set, asserting that `resources/`, `dictionaries/`, `lualibs/` and `luascripts/` land next to every binary in both zips. The end-to-end proof will come with the next tagged release.

Fixes #13